### PR TITLE
Added support for multi-row visualizations

### DIFF
--- a/src/components/comparisonsConfig/index.tsx
+++ b/src/components/comparisonsConfig/index.tsx
@@ -11,7 +11,7 @@ export interface SammenligningTemplate {
   path: string;
   query?: QueryObject;
   HeaderComponent?: React.ComponentClass<ComparisonHeaderProps<any>>;
-  render: (data: any, config?: any) => JSX.Element;
+  render: (data: any, config?: any, rowIndex?: number) => JSX.Element;
 }
 
 const exported: { [key: string]: SammenligningTemplate[] } = {

--- a/src/components/pages/ComparisonPage/ComparisonCell.tsx
+++ b/src/components/pages/ComparisonPage/ComparisonCell.tsx
@@ -8,6 +8,7 @@ type Props = {
   data: any;
   config: any;
   comparison: SammenligningTemplate;
+  rowIndex: number;
 };
 
 type State = { error: boolean };
@@ -21,10 +22,10 @@ class ComparisonCell extends Component<Props, State> {
   render() {
     if (!this.state.error)
       try {
-        const { data, config, comparison } = this.props;
+        const { data, config, comparison, rowIndex } = this.props;
         return (
           <div className={`${styles.flex_item} ${styles.item}`}>
-            {data ? comparison.render(data, config) : <NoData />}
+            {data ? comparison.render(data, config, rowIndex) : <NoData />}
           </div>
         );
       } catch (error) {

--- a/src/components/pages/ComparisonPage/ComparisonRow.tsx
+++ b/src/components/pages/ComparisonPage/ComparisonRow.tsx
@@ -19,36 +19,48 @@ class ComparisonRow extends Component<Props, State> {
   setConfig = (config: any) => {
     this.setState(config);
   };
+  renderRow(rowIndex: number) {
+    const { comparison, comparisonTypes, rowData } = this.props;
+    const config = this.state;
+
+    return comparisonTypes.map((uno_id, i) => {
+      const data = rowData ? rowData[uno_id] : null;
+      return (
+        <ComparisonCell
+          key={i}
+          data={data}
+          config={config}
+          comparison={comparison}
+          rowIndex={rowIndex}
+        />
+      );
+    });
+  }
   render() {
     const { comparison, comparisonTypes, rowData } = this.props;
     const config = this.state;
+    const HeaderComponent = comparison.HeaderComponent || ComparisonHeader;
+    let content: JSX.Element[];
+    if (config.rows) {
+      content = (config.rows as string[]).map((row, rowIndex) => (
+        <div key={rowIndex}>
+          <h4>{row}</h4>
+          {this.renderRow(rowIndex)}
+        </div>
+      ));
+    } else {
+      content = this.renderRow(0);
+    }
     return (
       <div>
-        {comparison.HeaderComponent ? (
-          <comparison.HeaderComponent
-            comparison={comparison}
-            config={config}
-            setConfig={this.setConfig}
-          />
-        ) : (
-          <ComparisonHeader
-            comparison={comparison}
-            config={config}
-            setConfig={this.setConfig}
-          />
-        )}
         <div className={styles.flex_container_row}>
-          {comparisonTypes.map((uno_id, i) => {
-            const data = rowData ? rowData[uno_id] : null;
-            return (
-              <ComparisonCell
-                key={i}
-                data={data}
-                config={config}
-                comparison={comparison}
-              />
-            );
-          })}
+          <HeaderComponent
+            comparison={comparison}
+            config={config}
+            setConfig={this.setConfig}
+          >
+            {content}
+          </HeaderComponent>
         </div>
       </div>
     );

--- a/src/components/visualizations/Shared/ComparisonHeader.tsx
+++ b/src/components/visualizations/Shared/ComparisonHeader.tsx
@@ -6,17 +6,21 @@ import { SammenligningTemplate } from "../../comparisonsConfig";
 
 export interface ComparisonHeaderProps<T> {
   comparison: SammenligningTemplate;
+  children: JSX.Element[];
   config: T;
   setConfig: (config: T) => void;
 }
 
 class ComparisonHeader extends Component<ComparisonHeaderProps<any>> {
   render() {
-    const { comparison } = this.props;
+    const { comparison, children } = this.props;
     return (
-      <h3 className={`${styles.flex_item} ${styles.item_title}`}>
-        {comparison.title}
-      </h3>
+      <div>
+        <h3 className={`${styles.flex_item} ${styles.item_title}`}>
+          {comparison.title}
+        </h3>
+        {children}
+      </div>
     );
   }
 }


### PR DESCRIPTION
Usikker på om dette holder, men det blir i alle fall veldig generisk.

```config``` som sendes fra header til cellene / radene inneholder en property ```config.rows : string[]``` og hvert kall til `render` får inn ``rowIndex`` som er posisjonen til raden.